### PR TITLE
Change SHA256 to Bitcoin-like SHA256d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# a.out and such
+a.out
+
 # User-specific files
 *.suo
 *.user

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Because of std::cin ignoring spaces, including newlines, use getline(std::cin, i
 
 To compile, rename main.cpp to main.cu, which nvcc recognizes.  Then compile:
 
-$ nvcc -o hash_program main.cu
+`$ nvcc -o hash_program main.cu`
 
 Example run:
 
+```
 james@acer-nitro5:~/src/cuda/SHA256CUDA$ ./hash_program 
 Entrez un message : This is a test
 Nonce : 0
@@ -19,6 +20,7 @@ Nonce : 8388608
 30226098This is a test
 00000001adff67cab9570a236d8490c0f5efee91e0303562e2d95ff7c3b7f3ec
 james@acer-nitro5:~/src/cuda/SHA256CUDA$
+```
 
 If you start it with a higher nonce, and give it more work to do, the hashrate will be higher.
 On my system with a GTX 1050 GPU, I get 6.5 million hash/s.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # SHA256CUDA
+
+Because of std::cin ignoring spaces, including newlines, use getline(std::cin, in) instead.
+
+To compile, rename main.cpp to main.cu, which nvcc recognizes.  Then compile:
+
+$ nvcc -o hash_program main.cu
+
+Example run:
+
+james@acer-nitro5:~/src/cuda/SHA256CUDA$ ./hash_program 
+Entrez un message : This is a test
+Nonce : 0
+Difficulte : 7
+
+Shared memory is 16400B
+772009 hash(es)/s
+Nonce : 8388608
+30226098This is a test
+00000001adff67cab9570a236d8490c0f5efee91e0303562e2d95ff7c3b7f3ec
+james@acer-nitro5:~/src/cuda/SHA256CUDA$
+
+If you start it with a higher nonce, and give it more work to do, the hashrate will be higher.
+On my system with a GTX 1050 GPU, I get 6.5 million hash/s.
+

--- a/README.md
+++ b/README.md
@@ -23,5 +23,36 @@ james@acer-nitro5:~/src/cuda/SHA256CUDA$
 ```
 
 If you start it with a higher nonce, and give it more work to do, the hashrate will be higher.
-On my system with a GTX 1050 GPU, I get 6.5 million hash/s.
+On my system with a GTX 1050 GPU, I get 6.5-12 million hash/s.
 
+With sha256d:
+
+```
+james@acer-nitro5:~/src/cuda/SHA256CUDA/SHA256CUDA$ ./hash_test 
+Entrez un message : Hello, world
+Nonce : 0
+Difficulte : 7
+
+Shared memory is 16793600KB
+608525 hash(es)/s
+Nonce : 8388608
+2926219 hash(es)/s
+Nonce : 41943040
+5081728 hash(es)/s
+Nonce : 75497472
+7091294 hash(es)/s
+Nonce : 109051904
+8966579 hash(es)/s
+Nonce : 142606336
+10721864 hash(es)/s
+Nonce : 176160768
+12366523 hash(es)/s
+Nonce : 209715200
+209884948Hello, world
+0000000af41bfb840272cf865799484235d775c343f6a7f0435828e1b17b2ff4
+
+james@acer-nitro5:~/src/cuda/SHA256CUDA/SHA256CUDA$ echo -n "209884948Hello, world" | sha256sum | cut -d' ' -f1 | xxd -r -p | sha256sum
+0000000af41bfb840272cf865799484235d775c343f6a7f0435828e1b17b2ff4  -
+
+james@acer-nitro5:~/src/cuda/SHA256CUDA/SHA256CUDA$
+```

--- a/SHA256CUDA/main.cu
+++ b/SHA256CUDA/main.cu
@@ -1,6 +1,6 @@
 
-#include "cuda_runtime.h"
-#include "device_launch_parameters.h"
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
 #include <iostream>
 #include <chrono>
 #include <cmath>
@@ -8,6 +8,8 @@
 #include <iomanip>
 #include <string>
 #include <cassert>
+#include <cstring>
+
 #include "main.h"
 #include "sha256.cuh"
 
@@ -155,7 +157,7 @@ int main() {
 	std::string in;
 	
 	std::cout << "Entrez un message : ";
-	std::cin >> in;
+	getline(std::cin, in);
 
 
 	std::cout << "Nonce : ";
@@ -214,7 +216,8 @@ int main() {
 
 	cudaDeviceReset();
 
-	system("pause");
+	// Windows
+	// system("pause");
 
 	return 0;
 }


### PR DESCRIPTION
This demonstrates finding a pre-image with partial match using Bitcoin's proof of work hashing, double SHA256 (sha256d).

getline() has been used for a longer message instead of cin, the README is updated, system("pause") removed and the cuda headers are in angle brackets, since nvcc knows where they are.